### PR TITLE
Fixed a bug that would cause DependenSee to crash on package version update

### DIFF
--- a/DependenSee/ReferenceDiscoveryService.cs
+++ b/DependenSee/ReferenceDiscoveryService.cs
@@ -139,7 +139,8 @@ namespace DependenSee
             var packages = new List<Package>();
             foreach (XmlNode node in packageReferenceNodes)
             {
-                var packageName = node.Attributes["Include"].Value;
+                var packageName = node.Attributes["Include"]?.Value
+                               ?? node.Attributes["Update"].Value;
 
                 packages.Add(new Package
                 {


### PR DESCRIPTION
The current implementation of DependenSee doesn't support scenarios, in which a dependency gets added to a project by a meta project like `Directory.Build.props`.
DependenSee crashes though, when a transitive package reference is forcibly updated in a parsed project file using `<PackageReference Update="..." />` (given that package discovery is enabled).

E.g.:
```xml
<!-- Directory.Build.props -->
    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
```
```xml
<!-- Some .csproj in a child folder, therefore Directory.Build.props gets applied -->
    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.7.1" />
```

The major difference here is, that there is no `Include` attribute, that could be parsed, resulting in a `NullReferenceException` on execution.

The proposed solution simply searches for an `Update` attribute as a fallback, when `Version` is not present.


**Note:** The PR does *not* implement a traversal mechanism for meta project types like `Common.props` or `Directory.Build.props`,...

CC @LuEbe , @JulianWurzer