### PR TITLE
Enable support for Graphviz output

### DIFF
--- a/DependenSee/GraphVizSerializer.cs
+++ b/DependenSee/GraphVizSerializer.cs
@@ -1,0 +1,44 @@
+﻿using System.CodeDom.Compiler;
+using System.IO;
+
+namespace DependenSee
+{
+    public static class GraphvizSerializer
+    {
+        const string ProjectBackgroundColor = "#00cc22";
+        const string PackageBackgroundColor = "#22aaee";
+
+        public static string ToString(DiscoveryResult discoveryResult)
+        {
+            using var stringWriter = new StringWriter();
+            using var writer = new IndentedTextWriter(stringWriter);
+
+            writer.WriteLine("digraph dependencies {");
+
+            writer.Indent++;
+
+            foreach (var project in discoveryResult.Projects)
+            {
+                writer.WriteLine($"\"{project.Id}\" [label=\"{project.Name}\", fillcolor=\"{ProjectBackgroundColor}\", style=filled];");
+            }
+
+            foreach (var package in discoveryResult.Packages)
+            {
+                writer.WriteLine($"\"{package.Id}\" [label=\"{package.Name}\", fillcolor=\"{PackageBackgroundColor}\", style=filled];");
+            }
+
+            foreach (var reference in discoveryResult.References)
+            {
+                writer.WriteLine($"\"{reference.From}\" -> \"{reference.To}\";");
+            }
+
+            writer.Indent--;
+
+            writer.WriteLine("}");
+
+            writer.Flush();
+
+            return stringWriter.ToString();
+        }
+    }
+}

--- a/DependenSee/PowerArgsProgram.cs
+++ b/DependenSee/PowerArgsProgram.cs
@@ -7,8 +7,10 @@ namespace DependenSee
         [ArgDescription("Creates an html document.")] Html,
         [ArgDescription("Creates a JSON file.")] Json,
         [ArgDescription("Creates a XML file.")] Xml,
+        [ArgDescription("Creates a Graphviz/DOT file.")] Graphviz,
         [ArgDescription("Writes JSON output to stdout")] ConsoleJson,
         [ArgDescription("Writes XML output to stdout")] ConsoleXml,
+        [ArgDescription("Writes Graphviz output to stdout")] ConsoleGraphviz,
     }
 
     [ArgExceptionBehavior(ArgExceptionPolicy.StandardExceptionHandling)]

--- a/DependenSee/ResultWriter.cs
+++ b/DependenSee/ResultWriter.cs
@@ -17,6 +17,7 @@ namespace DependenSee
                 case OutputTypes.Html:
                 case OutputTypes.Xml:
                 case OutputTypes.Json:
+                case OutputTypes.Graphviz:
                     if (string.IsNullOrWhiteSpace(outputPath))
                     {
                         Console.Error.WriteLine($"output type {type} require specifying {nameof(outputPath)}");
@@ -36,11 +37,17 @@ namespace DependenSee
                 case OutputTypes.Json:
                     WriteAsJsonToFile(result, outputPath);
                     break;
+                case OutputTypes.Graphviz:
+                    WriteAsGraphvizToFile(result, outputPath);
+                    break;
                 case OutputTypes.ConsoleJson:
                     WriteAsJsonToConsole(result);
                     break;
                 case OutputTypes.ConsoleXml:
                     WriteAsXmlToConsole(result);
+                    break;
+                case OutputTypes.ConsoleGraphviz:
+                    WriteAsGraphvizToConsole(result);
                     break;
                 default:
                     throw new Exception($"Unknown {nameof(type)} '{type}'");
@@ -79,5 +86,15 @@ namespace DependenSee
         }
         private void WriteAsJsonToConsole(DiscoveryResult result) =>
             Console.WriteLine(JsonConvert.SerializeObject(result, Formatting.Indented));
+
+        private static void WriteAsGraphvizToConsole(DiscoveryResult result) 
+            => Console.WriteLine(GraphvizSerializer.ToString(result));
+
+        private static void WriteAsGraphvizToFile(DiscoveryResult result, string outputPath)
+        {
+            File.WriteAllText(outputPath, GraphvizSerializer.ToString(result));
+            Console.WriteLine($"GraphViz output written to {outputPath}");
+        }
+
     }
 }


### PR DESCRIPTION
This PR introduces support for the Graphviz/DOT-specification. (https://graphviz.org/)
Since Graphviz is a mighty description language for graphs, it felt right to enable it for a tool, that builds dependency graphs.

I tried to adhere to the coding structure that is already there, feel free to adjust it to your liking.

I also didn't want to bring in heavy depenencies, that's why I factored the Graphviz statements manually.