### PR TITLE
Add support for custom titles in HTML output

### DIFF
--- a/DependenSee/HtmlResultTemplate.html
+++ b/DependenSee/HtmlResultTemplate.html
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-    <title>DependenSee</title>
+    <title>{#TITLE_TOKEN#}</title>
     <meta name="color-scheme" content="dark light">
 
     <style type="text/css">

--- a/DependenSee/PowerArgsProgram.cs
+++ b/DependenSee/PowerArgsProgram.cs
@@ -48,6 +48,11 @@ namespace DependenSee
         [ArgDescription("Type of the output.")]
         [ArgShortcut("T")]
         public OutputTypes OutputType { get; set; }
+        
+        [ArgDefaultValue("DependenSee")]
+        [ArgDescription("Document title for Html output. Ignored for other output types.")]
+        [ArgShortcut("HT")]
+        public string HtmlTitle { get; set; }
 
         [ArgDefaultValue("")]
         [ArgDescription("Comma separated list of project file prefixes to include. Wildcards not allowed. Only the filename is considered, case insensitive. Ex:'MyApp.Core, MyApp.Extensions' Includes only projects starting with MyApp.Core and projects starting with MyApp.Extensions")]
@@ -84,7 +89,7 @@ namespace DependenSee
                 SourceFolder = SourceFolder,
             };
             var result = service.Discover();
-            new ResultWriter().Write(result, OutputType, OutputPath);
+            new ResultWriter().Write(result, OutputType, OutputPath, HtmlTitle);
         }
     }
 }

--- a/DependenSee/ResultWriter.cs
+++ b/DependenSee/ResultWriter.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.IO;
+using System.Net;
 using System.Reflection;
 using System.Xml.Serialization;
 
@@ -9,8 +10,9 @@ namespace DependenSee
     internal class ResultWriter
     {
         private const string HtmlTemplateToken = "'{#SOURCE_TOKEN#}'";
+        private const string HtmlTitleToken = "{#TITLE_TOKEN#}";
         private const string HtmlTemplateName = "HtmlResultTemplate.html";
-        internal void Write(DiscoveryResult result, OutputTypes type, string outputPath)
+        internal void Write(DiscoveryResult result, OutputTypes type, string outputPath, string htmlTitle)
         {
             switch (type)
             {
@@ -29,7 +31,7 @@ namespace DependenSee
             switch (type)
             {
                 case OutputTypes.Html:
-                    WriteAsHtmlToFile(result, outputPath);
+                    WriteAsHtmlToFile(result, outputPath, htmlTitle);
                     break;
                 case OutputTypes.Xml:
                     WriteAsXmlToFile(result, outputPath);
@@ -54,11 +56,13 @@ namespace DependenSee
             }
         }
 
-        private void WriteAsHtmlToFile(DiscoveryResult result, string outputPath)
+        private void WriteAsHtmlToFile(DiscoveryResult result, string outputPath, string title)
         {
             var templatePath = Path.Combine(new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName, HtmlTemplateName);
             var template = File.ReadAllText(templatePath);
-            var html = template.Replace(HtmlTemplateToken, JsonConvert.SerializeObject(result, Formatting.Indented));
+            var html = template
+                .Replace(HtmlTemplateToken, JsonConvert.SerializeObject(result, Formatting.Indented))
+                .Replace(HtmlTitleToken, WebUtility.HtmlEncode(title));
 
             File.WriteAllText(outputPath, html);
             Console.WriteLine($"HTML output written to {outputPath}");

--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ To visualize Graphviz output, either use
 - `DependenSee \Source\SolutionFolder \Test\MyOutput.html -OutputType Json`
 - `DependenSee \Source\SolutionFolder -T ConsoleJson`
 
+## HtmlTitle
+
+Document title for Html output. Ignored when creating output types other than `Html`.
+
+If your title has spaces, you will need to enclose it in double quotes. The title should not be HTML-encoded ahead of time as DependenSee will do this automatically.
+
+**Shorthand: `-HT`**
+
+**Default: `DependenSee`**
+
+### Examples
+
+- `DependenSee \Source\SolutionFolder \Test\MyOutput.html -HtmlTitle "My Graph Title"`
+- `DependenSee \Source\SolutionFolder \Test\MyOutput.html -T Html -HtmlTitle my-graph-title`
+- `DependenSee \Source\SolutionFolder \Test\MyOutput.html -HT "My Graph Title"`
+
 ## IncludeProjectNamespaces
 Comma separated list of project file prefixes to include. Wildcards not allowed. Only the filename is considered, case insensitive. 
 


### PR DESCRIPTION
* Added `-HtmlTitle` (`-HT`) option to specify a title for HTML output. Feature #11
* Updated README.md to reflect the new changes

Resolves #11 