### PR TITLE
Support VB.NET Projects

### DIFF
--- a/DependenSee/ReferenceDiscoveryService.cs
+++ b/DependenSee/ReferenceDiscoveryService.cs
@@ -58,7 +58,8 @@ namespace DependenSee
 
         private void Discover(string folder, DiscoveryResult result)
         {
-            var projectFiles = Directory.EnumerateFiles(folder, "*.csproj");
+            var projectFiles = Directory.EnumerateFiles(folder, "*.csproj")
+                .Concat(Directory.EnumerateFiles(folder, "*.vbproj"));
             foreach (var file in projectFiles)
             {
                 var id = file.Replace(SourceFolder, "");


### PR DESCRIPTION
vbproj files have the same format as csproj files and so can
also be used to gain information about referenced projects and
packages.