### PR TITLE
Issue26 feature dicover from solution file

### DIFF
--- a/DependenSee/PowerArgsProgram.cs
+++ b/DependenSee/PowerArgsProgram.cs
@@ -11,13 +11,6 @@ public enum OutputTypes
     [ArgDescription("Writes Graphviz output to stdout")] ConsoleGraphviz,
 }
 
-public enum ErrorCodes
-{
-    [ArgDescription("Success")] None,
-    [ArgDescription("Multiple solution files were found when using 'UseSingleSolutionFile' parameter. Specify solution files using 'SolutionFiles' instead or omit 'UseSingleSolutionFile' parameter")] MultipleSolutionFilesFound = 100,
-    [ArgDescription("No solution files were found")] NoSolutionFilesFound,
-}
-
 [ArgExceptionBehavior(ArgExceptionPolicy.StandardExceptionHandling)]
 [ArgDescription(@"
 
@@ -97,10 +90,6 @@ public class PowerArgsProgram
     [ArgShortcut("SF")]
     public string SolutionFiles { get; set; }
 
-    // Return value
-    [ArgDefaultValue(ErrorCodes.None)]
-    public ErrorCodes ErrorCode { get; set; }
-
 
     public void Main()
     {
@@ -127,7 +116,6 @@ public class PowerArgsProgram
         };
         var result = service.Discover();
 
-        ErrorCode = result.ErrorCode;
-        new ResultWriter().Write(result.DiscoveryResult, OutputType, OutputPath, HtmlTitle);
+        new ResultWriter().Write(result, OutputType, OutputPath, HtmlTitle);
     }
 }

--- a/DependenSee/Program.cs
+++ b/DependenSee/Program.cs
@@ -12,8 +12,15 @@ public static class Program
         }
         try
         {
-            Args.InvokeMain<PowerArgsProgram>(args);
-            return 0;
+            var objResult = Args.InvokeMain<PowerArgsProgram>(args);
+            var result = objResult.Value as PowerArgsProgram;
+            if (result.ErrorCode == ErrorCodes.None)
+            {
+                return 0;
+            }
+
+            WriteErrorMessages(result);
+            return (int)result.ErrorCode;
         }
         catch (Exception ex)
         {
@@ -21,6 +28,21 @@ public static class Program
             return 1;
         }
     }
+
+    private static void WriteErrorMessages(PowerArgsProgram result)
+    {
+        var currentColor = Console.ForegroundColor;
+        Console.ForegroundColor = ConsoleColor.Yellow;
+
+        var errorCodeType = result.ErrorCode.GetType();
+        var errorCodeValueMember = errorCodeType.GetField(result.ErrorCode.ToString());
+        var argDescription = errorCodeValueMember.GetCustomAttribute<ArgDescription>();
+
+        Console.WriteLine(argDescription.Description);
+
+        Console.ForegroundColor = currentColor;
+    }
+
 
     private static void WriteUnexpectedException(Exception ex)
     {

--- a/DependenSee/Program.cs
+++ b/DependenSee/Program.cs
@@ -12,15 +12,8 @@ public static class Program
         }
         try
         {
-            var objResult = Args.InvokeMain<PowerArgsProgram>(args);
-            var result = objResult.Value as PowerArgsProgram;
-            if (result.ErrorCode == ErrorCodes.None)
-            {
-                return 0;
-            }
-
-            WriteErrorMessages(result);
-            return (int)result.ErrorCode;
+            Args.InvokeMain<PowerArgsProgram>(args);
+            return 0;
         }
         catch (Exception ex)
         {
@@ -28,21 +21,6 @@ public static class Program
             return 1;
         }
     }
-
-    private static void WriteErrorMessages(PowerArgsProgram result)
-    {
-        var currentColor = Console.ForegroundColor;
-        Console.ForegroundColor = ConsoleColor.Yellow;
-
-        var errorCodeType = result.ErrorCode.GetType();
-        var errorCodeValueMember = errorCodeType.GetField(result.ErrorCode.ToString());
-        var argDescription = errorCodeValueMember.GetCustomAttribute<ArgDescription>();
-
-        Console.WriteLine(argDescription.Description);
-
-        Console.ForegroundColor = currentColor;
-    }
-
 
     private static void WriteUnexpectedException(Exception ex)
     {

--- a/DependenSee/ReferenceDiscoveryService.cs
+++ b/DependenSee/ReferenceDiscoveryService.cs
@@ -12,6 +12,8 @@ public class ReferenceDiscoveryService
     public string ExcludePackageNamespaces { get; set; }
     public bool FollowReparsePoints { get; set; }
     public string ExcludeFolders { get; set; }
+    public string SolutionFiles { get; set; }
+    public bool UseSingleSolutionFile { get; set; }
 
     private string[] _includeProjectNamespaces { get; set; }
     private string[] _excludeProjectNamespaces { get; set; }
@@ -20,7 +22,9 @@ public class ReferenceDiscoveryService
 
     private bool _shouldIncludePackages { get; set; }
 
-    public DiscoveryResult Discover()
+    private ErrorCodes _errorCode { get; set; }
+
+    public (DiscoveryResult DiscoveryResult, ErrorCodes ErrorCode) Discover()
     {
         var result = new DiscoveryResult
         {
@@ -42,7 +46,8 @@ public class ReferenceDiscoveryService
             || !string.IsNullOrWhiteSpace(ExcludePackageNamespaces);
 
         Discover(SourceFolder, result);
-        return result;
+
+        return (result, _errorCode);
     }
 
     private static string[] ParseStringToLowercaseStringArray(string list) =>


### PR DESCRIPTION
Adding support for discovering projects to investigate based on either the single solution file in the folder (Command line parameter `UseSingleSolutionFile`) or a comma separated list of solution files (Command line parameter `SolutionFiles`)

Actual way of discovering references from a project file is the same as for the original functionality.