### PR TITLE
Extract ReferenceDiscoveryService to DependenSee.Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,6 @@ MigrationBackup/
 FodyWeavers.xsd
 
 */Properties/launchSettings.json
+
+#Jetbrains folder
+.idea/

--- a/DependenSee.Core/DependenSee.Core.csproj
+++ b/DependenSee.Core/DependenSee.Core.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>true</IsPackable>
+        <PackageOutputPath>../bin/nupkg</PackageOutputPath>
+        <Version>2.2.1</Version>
+    </PropertyGroup>
+    <PropertyGroup>      
+        <Authors>Madushan</Authors>
+        <Description>Dotnet Library to export project and package dependencies.</Description>
+        <PackageTags>dependency, visualizer, dependensee</PackageTags>
+        <RepositoryUrl>https://github.com/madushans/DependenSee</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/madushans/DependenSee</PackageProjectUrl>
+    </PropertyGroup>
+</Project>

--- a/DependenSee.Core/Models.cs
+++ b/DependenSee.Core/Models.cs
@@ -9,7 +9,7 @@ public class DiscoveryResult
 
 public class Project
 {
-    public  string Id { get; set; }
+    public string Id { get; set; }
     public string Name { get; set; }
 }
 public class Package

--- a/DependenSee.Core/Models.cs
+++ b/DependenSee.Core/Models.cs
@@ -1,4 +1,4 @@
-﻿namespace DependenSee;
+﻿namespace DependenSee.Core;
 
 public class DiscoveryResult
 {
@@ -9,7 +9,7 @@ public class DiscoveryResult
 
 public class Project
 {
-    public string Id { get; set; }
+    public  string Id { get; set; }
     public string Name { get; set; }
 }
 public class Package

--- a/DependenSee.Core/ReferenceDiscoveryService.cs
+++ b/DependenSee.Core/ReferenceDiscoveryService.cs
@@ -1,11 +1,11 @@
-﻿namespace DependenSee;
+﻿using DependenSee.Core;
+
+namespace DependenSee.Library;
 
 public class ReferenceDiscoveryService
 {
     public string SourceFolder { get; set; }
-    public string OutputPath { get; set; }
     public bool IncludePackages { get; set; }
-    public OutputTypes OutputType { get; set; }
     public string IncludeProjectNamespaces { get; set; }
     public string ExcludeProjectNamespaces { get; set; }
     public string IncludePackageNamespaces { get; set; }
@@ -70,7 +70,7 @@ public class ReferenceDiscoveryService
         }
         if (info.Attributes.HasFlag(FileAttributes.ReparsePoint) && !FollowReparsePoints)
         {
-            Console.Error.WriteLine($"Skipping scan for reparse point '{folder}'. Set {nameof(PowerArgsProgram.FollowReparsePoints)} flag to follow.\r\n\r\n");
+            Console.Error.WriteLine($"Skipping scan for reparse point '{folder}'. Set {nameof(FollowReparsePoints)} flag to follow.\r\n\r\n");
             return;
         }
 

--- a/DependenSee.Core/globalusings.cs
+++ b/DependenSee.Core/globalusings.cs
@@ -1,0 +1,10 @@
+global using System.CodeDom.Compiler;
+global using System.IO;
+global using System.Collections.Generic;
+global using System;
+global using System.Net;
+global using System.Reflection;
+global using System.Xml.Serialization;
+global using System.Linq;
+global using System.Xml;
+global using System.Text.Json;

--- a/DependenSee.sln
+++ b/DependenSee.sln
@@ -5,6 +5,17 @@ VisualStudioVersion = 16.0.30717.126
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependenSee", "DependenSee\DependenSee.csproj", "{6C4DA9BF-3DEC-4794-8E63-3F066A0C7361}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependenSee.Core", "DependenSee.Core\DependenSee.Core.csproj", "{C61891FA-4ACB-421C-9D0D-093AAA166731}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionFolder", "SolutionFolder", "{BBE4D3AC-68B2-46EE-9120-DFD93E780100}"
+	ProjectSection(SolutionItems) = preProject
+		LICENSE = LICENSE
+		README.md = README.md
+		azure-pipelines.yml = azure-pipelines.yml
+		sample-html-output.html = sample-html-output.html
+		sample-output.png = sample-output.png
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +26,10 @@ Global
 		{6C4DA9BF-3DEC-4794-8E63-3F066A0C7361}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6C4DA9BF-3DEC-4794-8E63-3F066A0C7361}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6C4DA9BF-3DEC-4794-8E63-3F066A0C7361}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C61891FA-4ACB-421C-9D0D-093AAA166731}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C61891FA-4ACB-421C-9D0D-093AAA166731}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C61891FA-4ACB-421C-9D0D-093AAA166731}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C61891FA-4ACB-421C-9D0D-093AAA166731}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DependenSee/DependenSee.csproj
+++ b/DependenSee/DependenSee.csproj
@@ -6,8 +6,8 @@
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>DependenSee</ToolCommandName>
-    <PackageOutputPath>./bin/nupkg</PackageOutputPath>
-    <Version>2.2.0</Version>
+    <PackageOutputPath>../bin/nupkg</PackageOutputPath>
+    <Version>2.2.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,5 +31,9 @@
 
   <ItemGroup>
     <None Include="LICENSE.txt" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DependenSee.Core\DependenSee.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/DependenSee/GraphVizSerializer.cs
+++ b/DependenSee/GraphVizSerializer.cs
@@ -1,4 +1,7 @@
-﻿namespace DependenSee;
+﻿using DependenSee.Core;
+using DependenSee.Library;
+
+namespace DependenSee;
 public static class GraphvizSerializer
 {
     const string ProjectBackgroundColor = "#00cc22";

--- a/DependenSee/PowerArgsProgram.cs
+++ b/DependenSee/PowerArgsProgram.cs
@@ -1,4 +1,6 @@
-﻿namespace DependenSee;
+﻿using DependenSee.Library;
+
+namespace DependenSee;
 
 public enum OutputTypes
 {
@@ -92,9 +94,6 @@ public class PowerArgsProgram
 
             ExcludeFolders = ExcludeFolders,
             FollowReparsePoints = FollowReparsePoints,
-
-            OutputPath = OutputPath,
-            OutputType = OutputType,
 
             SourceFolder = SourceFolder,
 

--- a/DependenSee/ResultWriter.cs
+++ b/DependenSee/ResultWriter.cs
@@ -1,4 +1,7 @@
-﻿namespace DependenSee;
+﻿using DependenSee.Core;
+using DependenSee.Library;
+
+namespace DependenSee;
 
 internal class ResultWriter
 {


### PR DESCRIPTION
- feat(ReferenceDiscoveryService) make it possible to publish DependenSee as a NuGet Package and not only as a tool.


For now I only extracted the ReferenceDiscoveryService to a new project, didn't want to change the overall structure to much for now. I think it is a good idea to add the required properties in the constructor of ReferenceDiscoveryService (for example `SourceFolder`

This PR will fix #28 