### PR TITLE
Added deep nesting option to display the dependency of the depended projects

### DIFF
--- a/DependenSee/PowerArgsProgram.cs
+++ b/DependenSee/PowerArgsProgram.cs
@@ -41,6 +41,11 @@ public class PowerArgsProgram
     [ArgShortcut("P")]
     public bool IncludePackages { get; set; }
 
+    [ArgDefaultValue(false)]
+    [ArgDescription("Whether the system should discover and map the dependency projects that have been identified")]
+    [ArgShortcut("DN")]
+    public bool DeepNesting { get; set; }
+
     [ArgDefaultValue(OutputTypes.Html)]
     [ArgDescription("Type of the output. Warnings are written to stderr. If you're piping the stdout, you may also want to check the stderr.")]
     [ArgShortcut("T")]
@@ -89,6 +94,7 @@ public class PowerArgsProgram
             IncludeProjectNamespaces = IncludeProjectNamespaces,
 
             IncludePackages = IncludePackages,
+            DeepNesting = DeepNesting,
 
             ExcludeFolders = ExcludeFolders,
             FollowReparsePoints = FollowReparsePoints,

--- a/DependenSee/ReferenceDiscoveryService.cs
+++ b/DependenSee/ReferenceDiscoveryService.cs
@@ -5,6 +5,8 @@ public class ReferenceDiscoveryService
     public string SourceFolder { get; set; }
     public string OutputPath { get; set; }
     public bool IncludePackages { get; set; }
+
+    public bool DeepNesting { get; set; }
     public OutputTypes OutputType { get; set; }
     public string IncludeProjectNamespaces { get; set; }
     public string ExcludeProjectNamespaces { get; set; }
@@ -108,6 +110,15 @@ public class ReferenceDiscoveryService
                     From = id,
                     To = project.Id
                 });
+
+                if (DeepNesting)
+                {
+                    var nested = Path.GetDirectoryName(project.Id);
+                    if (Directory.Exists(nested))
+                    {
+                        Discover(nested, result);
+                    }
+                }
             }
 
             if (!_shouldIncludePackages) continue;


### PR DESCRIPTION
Added a new option in the command line to generate dependencies of the identified depended on projects as well. This will help us to display a single diagram of all the dependencies.