### PR TITLE
Target newer frameworks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '9.0.x'
 
 jobs:
   build:

--- a/DependenSee/DependenSee.csproj
+++ b/DependenSee/DependenSee.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>DependenSee</ToolCommandName>

--- a/DependenSee/DependenSee.csproj
+++ b/DependenSee/DependenSee.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>DependenSee</ToolCommandName>

--- a/DependenSee/DependenSee.csproj
+++ b/DependenSee/DependenSee.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <PackAsTool>true</PackAsTool>

--- a/DependenSee/Models.cs
+++ b/DependenSee/Models.cs
@@ -2,24 +2,43 @@
 
 public class DiscoveryResult
 {
-    public List<Project> Projects { get; set; }
-    public List<Package> Packages { get; set; }
-    public List<Reference> References { get; set; }
+    public List<Project> Projects { get; } = new();
+    public List<Package> Packages { get; } = new();
+    public List<Reference> References { get; } = new();
 }
 
 public class Project
 {
-    public string Id { get; set; }
-    public string Name { get; set; }
+    public string Id { get; }
+    public string Name { get; }
+
+    public Project(string id, string name)
+    {
+        Id = id;
+        Name = name;
+    }
 }
+
 public class Package
 {
-    public string Id { get; set; }
-    public string Name { get; set; }
+    public string Id { get; }
+    public string Name { get; }
+
+    public Package(string id, string name)
+    {
+        Id = id;
+        Name = name;
+    }
 }
 
 public class Reference
 {
-    public string From { get; set; }
-    public string To { get; set; }
+    public string From { get; }
+    public string To { get; }
+
+    public Reference(string from, string to)
+    {
+        From = from;
+        To = to;
+    }
 }

--- a/DependenSee/Models.cs
+++ b/DependenSee/Models.cs
@@ -2,43 +2,25 @@
 
 public class DiscoveryResult
 {
-    public List<Project> Projects { get; } = new();
-    public List<Package> Packages { get; } = new();
-    public List<Reference> References { get; } = new();
+    public List<Project> Projects { get; } = [];
+    public List<Package> Packages { get; } = [];
+    public List<Reference> References { get; } = [];
 }
 
-public class Project
+public class Project(string id, string name)
 {
-    public string Id { get; }
-    public string Name { get; }
-
-    public Project(string id, string name)
-    {
-        Id = id;
-        Name = name;
-    }
+    public string Id { get; } = id;
+    public string Name { get; } = name;
 }
 
-public class Package
+public class Package(string id, string name)
 {
-    public string Id { get; }
-    public string Name { get; }
-
-    public Package(string id, string name)
-    {
-        Id = id;
-        Name = name;
-    }
+    public string Id { get; } = id;
+    public string Name { get; } = name;
 }
 
-public class Reference
+public class Reference(string from, string to)
 {
-    public string From { get; }
-    public string To { get; }
-
-    public Reference(string from, string to)
-    {
-        From = from;
-        To = to;
-    }
+    public string From { get; } = from;
+    public string To { get; } = to;
 }

--- a/DependenSee/PowerArgsProgram.cs
+++ b/DependenSee/PowerArgsProgram.cs
@@ -30,11 +30,11 @@ public class PowerArgsProgram
     [ArgPosition(0)]
     [ArgDescription("Root folder (usually solution folder) to look for csproj files recursively.")]
     [ArgExistingDirectory]
-    public string SourceFolder { get; set; }
+    public string? SourceFolder { get; set; }
 
     [ArgDescription("Path to write the result. Not required if writing the output to stdout")]
     [ArgPosition(1)]
-    public string OutputPath { get; set; }
+    public string? OutputPath { get; set; }
 
     [ArgDefaultValue(false)]
     [ArgDescription("Whether to include external (Nuget) packages in the result.")]
@@ -49,35 +49,34 @@ public class PowerArgsProgram
     [ArgDefaultValue("DependenSee")]
     [ArgDescription("Document title for Html output. Ignored for other output types.")]
     [ArgShortcut("HT")]
-    public string HtmlTitle { get; set; }
+    public string? HtmlTitle { get; set; }
 
     [ArgDefaultValue("")]
     [ArgDescription("Comma separated list of project file prefixes to include. Wildcards not allowed. Only the filename is considered, case insensitive. Ex:'MyApp.Core, MyApp.Extensions' Includes only projects starting with MyApp.Core and projects starting with MyApp.Extensions")]
     [ArgShortcut("IPrN")]
-    public string IncludeProjectNamespaces { get; set; }
+    public string? IncludeProjectNamespaces { get; set; }
 
     [ArgDescription("Comma separated list of project file prefixes to exclude. Wildcards not allowed. Only the filename is considered, case insensitive. This must be a subset of includes to be useful. Ex: 'MyApp.Extensions, MyApp.Helpers' Excludes projects starting with MyApp.Extensions and projects starting with MyApp.Helpers")]
     [ArgShortcut("EPrN")]
-    public string ExcludeProjectNamespaces { get; set; }
+    public string? ExcludeProjectNamespaces { get; set; }
 
     [ArgDefaultValue("")]
     [ArgDescription("Comma separated list of package name prefixes to include. Wildcards not allowed. Only the package name is considered, case insensitive. If specified, 'IncludePackages' is overridden to True. Ex: 'Xamarin, Microsoft' includes only packages starting with Xamarin and packages starting with Microsoft")]
     [ArgShortcut("IPaN")]
-    public string IncludePackageNamespaces { get; set; }
+    public string? IncludePackageNamespaces { get; set; }
 
     [ArgDescription("Comma separated list of package name prefixes to exclude. Wildcards not allowed. Only the filename is considered, case insensitive. If specified, 'IncludePackages' is overridden to True. This must be a subset of includes to be useful. Ex: 'Microsoft.Logging, Azure' Excludes packages starting with Microsoft.Logging and packages starting with Azure")]
     [ArgShortcut("EPaN")]
-    public string ExcludePackageNamespaces { get; set; }
+    public string? ExcludePackageNamespaces { get; set; }
     [ArgDefaultValue("")]
     [ArgDescription("Comma Separated list of folders (either absolute paths or relative to SourceFolder) to skip during scan, even if there are references to them from your projects.")]
     [ArgShortcut("EFol")]
-    public string ExcludeFolders { get; set; }
+    public string? ExcludeFolders { get; set; }
 
     [ArgDefaultValue(false)]
     [ArgDescription("Set if you want the scan to follow valid reparse points. This is helpful if your project references are relying on symlinks, NTFS junction points .etc.")]
     [ArgShortcut("FReP")]
     public bool FollowReparsePoints { get; set; }
-
 
     public void Main()
     {
@@ -100,6 +99,6 @@ public class PowerArgsProgram
 
         };
         var result = service.Discover();
-        new ResultWriter().Write(result, OutputType, OutputPath, HtmlTitle);
+        new ResultWriter().Write(result, OutputType, OutputPath!, HtmlTitle!);
     }
 }

--- a/DependenSee/Program.cs
+++ b/DependenSee/Program.cs
@@ -7,7 +7,7 @@ public static class Program
         {
             // if no arguments specified, instead of showing an error,
             // pretend as help command
-            Args.InvokeMain<PowerArgsProgram>(new[] { $"-{nameof(PowerArgsProgram.Help)}" });
+            Args.InvokeMain<PowerArgsProgram>([$"-{nameof(PowerArgsProgram.Help)}"]);
             return 0;
         }
         try

--- a/DependenSee/ResultWriter.cs
+++ b/DependenSee/ResultWriter.cs
@@ -5,7 +5,8 @@ internal class ResultWriter
     private const string HtmlTemplateToken = "'{#SOURCE_TOKEN#}'";
     private const string HtmlTitleToken = "{#TITLE_TOKEN#}";
     private const string HtmlTemplateName = "HtmlResultTemplate.html";
-    private JsonSerializerOptions _JsonSerializerOptions = new JsonSerializerOptions() { WriteIndented = true };
+
+    private readonly JsonSerializerOptions _JsonSerializerOptions = new() { WriteIndented = true };
 
     internal void Write(DiscoveryResult result, OutputTypes type, string outputPath, string htmlTitle)
     {
@@ -53,7 +54,7 @@ internal class ResultWriter
 
     private void WriteAsHtmlToFile(DiscoveryResult result, string outputPath, string title)
     {
-        var templatePath = Path.Combine(new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName, HtmlTemplateName);
+        var templatePath = Path.Combine(new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName!, HtmlTemplateName);
         var template = File.ReadAllText(templatePath);
         var html = template
             .Replace(HtmlTemplateToken, JsonSerializer.Serialize(result, _JsonSerializerOptions))
@@ -63,14 +64,14 @@ internal class ResultWriter
         Console.WriteLine($"HTML output written to {outputPath}");
     }
 
-    private void WriteAsXmlToConsole(DiscoveryResult result)
+    private static void WriteAsXmlToConsole(DiscoveryResult result)
     {
         var serializer = new XmlSerializer(typeof(DiscoveryResult));
         using var writeStream = Console.Out;
         serializer.Serialize(writeStream, result);
     }
 
-    private void WriteAsXmlToFile(DiscoveryResult result, string outputPath)
+    private static void WriteAsXmlToFile(DiscoveryResult result, string outputPath)
     {
         var serializer = new XmlSerializer(typeof(DiscoveryResult));
         using var writeStream = File.OpenWrite(outputPath);
@@ -83,6 +84,7 @@ internal class ResultWriter
         File.WriteAllText(outputPath, JsonSerializer.Serialize(result, _JsonSerializerOptions));
         Console.WriteLine($"JSON output written to {outputPath}");
     }
+
     private void WriteAsJsonToConsole(DiscoveryResult result) =>
         Console.WriteLine(JsonSerializer.Serialize(result, _JsonSerializerOptions));
 
@@ -94,5 +96,4 @@ internal class ResultWriter
         File.WriteAllText(outputPath, GraphvizSerializer.ToString(result));
         Console.WriteLine($"GraphViz output written to {outputPath}");
     }
-
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '6.0.x'
+    version: '9.0.x'
 
 - task: DotNetCoreCLI@2
   inputs:


### PR DESCRIPTION
Fixes #41

Target .NET 8 / .NET 9

I have taken the opportunity to enable nullable reference types so that the code is a little more protected:

https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references

EDIT: I know you have 3.x pending but in the meantime at least the 2.x code should contemplate nullable reference types.