### PR TITLE
Add mermaid output, trim namespace options

### DIFF
--- a/DependenSee/MermaidSerializer.cs
+++ b/DependenSee/MermaidSerializer.cs
@@ -1,0 +1,45 @@
+﻿namespace DependenSee;
+public static class MermaidSerializer
+{
+	const string ProjectBackgroundColor = "#00cc22";
+	const string PackageBackgroundColor = "#22aaee";
+
+	public static string ToString(DiscoveryResult discoveryResult)
+	{
+		using var stringWriter = new StringWriter();
+		using var writer = new IndentedTextWriter(stringWriter);
+
+		writer.WriteLine("graph LR");
+
+		writer.Indent++;
+
+		foreach (var project in discoveryResult.Projects)
+		{
+			writer.WriteLine($"{project.Id}[\"{project.Name}\"]:::project");
+		}
+
+		if (discoveryResult.Packages.Count > 0)
+		{
+			writer.WriteLine($"subgraph Packages");
+			foreach (var package in discoveryResult.Packages)
+			{
+				writer.WriteLine($"{package.Id}[\"{package.Name}\"]:::package");
+			}
+			writer.WriteLine("end");
+		}
+
+		foreach (var reference in discoveryResult.References)
+		{
+			writer.WriteLine($"{reference.From} --> {reference.To}");
+		}
+
+		writer.WriteLine($"classDef project fill:{ProjectBackgroundColor};");
+		writer.WriteLine($"classDef package fill:{PackageBackgroundColor};");
+
+		writer.Indent--;
+
+		writer.Flush();
+
+		return stringWriter.ToString();
+	}
+}

--- a/DependenSee/PowerArgsProgram.cs
+++ b/DependenSee/PowerArgsProgram.cs
@@ -62,6 +62,10 @@ public class PowerArgsProgram
     [ArgShortcut("EPrN")]
     public string ExcludeProjectNamespaces { get; set; }
 
+    [ArgDescription("Comma separated list of project file prefixes to trim from display. Wildcards not allowed. Only the filename is considered, case insensitive. Ex:'MyApp' trims display name of projects starting with 'MyApp'. 'MyApp.Core' and 'MyApp.Extensions' display as 'Core' and 'Extensions'")]
+    [ArgShortcut("TPrN")]
+    public string TrimProjectNamespaces { get; set; }
+
     [ArgDefaultValue("")]
     [ArgDescription("Comma separated list of package name prefixes to include. Wildcards not allowed. Only the package name is considered, case insensitive. If specified, 'IncludePackages' is overridden to True. Ex: 'Xamarin, Microsoft' includes only packages starting with Xamarin and packages starting with Microsoft")]
     [ArgShortcut("IPaN")]
@@ -70,6 +74,11 @@ public class PowerArgsProgram
     [ArgDescription("Comma separated list of package name prefixes to exclude. Wildcards not allowed. Only the filename is considered, case insensitive. If specified, 'IncludePackages' is overridden to True. This must be a subset of includes to be useful. Ex: 'Microsoft.Logging, Azure' Excludes packages starting with Microsoft.Logging and packages starting with Azure")]
     [ArgShortcut("EPaN")]
     public string ExcludePackageNamespaces { get; set; }
+
+    [ArgDescription("Comma separated list of package name prefixes to trim from display. Wildcards not allowed. Only the package name is considered, case insensitive. If specified, `-IncludePackages` is overridden to `True`. Ex:'MyApp' trims display name of packages starting with 'MyApp'. 'MyApp.Core' and 'MyApp.Extensions' display as 'Core' and 'Extensions'")]
+    [ArgShortcut("TPaN")]
+    public string TrimPackageNamespaces { get; set; }
+
     [ArgDefaultValue("")]
     [ArgDescription("Comma Separated list of folders (either absolute paths or relative to SourceFolder) to skip during scan, even if there are references to them from your projects.")]
     [ArgShortcut("EFol")]
@@ -80,7 +89,6 @@ public class PowerArgsProgram
     [ArgShortcut("FReP")]
     public bool FollowReparsePoints { get; set; }
 
-
     public void Main()
     {
         var service = new ReferenceDiscoveryService
@@ -89,6 +97,8 @@ public class PowerArgsProgram
             ExcludeProjectNamespaces = ExcludeProjectNamespaces,
             IncludePackageNamespaces = IncludePackageNamespaces,
             IncludeProjectNamespaces = IncludeProjectNamespaces,
+            TrimPackageNamespaces = TrimPackageNamespaces,
+            TrimProjectNamespaces = TrimProjectNamespaces,
 
             IncludePackages = IncludePackages,
 
@@ -99,7 +109,6 @@ public class PowerArgsProgram
             OutputType = OutputType,
 
             SourceFolder = SourceFolder,
-
         };
         var result = service.Discover();
         new ResultWriter().Write(result, OutputType, OutputPath, HtmlTitle);

--- a/DependenSee/PowerArgsProgram.cs
+++ b/DependenSee/PowerArgsProgram.cs
@@ -6,9 +6,11 @@ public enum OutputTypes
     [ArgDescription("Creates a JSON file.")] Json,
     [ArgDescription("Creates a XML file.")] Xml,
     [ArgDescription("Creates a Graphviz/DOT file.")] Graphviz,
+    [ArgDescription("Creates a Mermaid/MMD file.")] Mermaid,
     [ArgDescription("Writes JSON output to stdout")] ConsoleJson,
     [ArgDescription("Writes XML output to stdout")] ConsoleXml,
     [ArgDescription("Writes Graphviz output to stdout")] ConsoleGraphviz,
+    [ArgDescription("Writes Mermaid output to stdout")] ConsoleMermaid,
 }
 
 [ArgExceptionBehavior(ArgExceptionPolicy.StandardExceptionHandling)]

--- a/DependenSee/ResultWriter.cs
+++ b/DependenSee/ResultWriter.cs
@@ -15,6 +15,7 @@ internal class ResultWriter
             case OutputTypes.Xml:
             case OutputTypes.Json:
             case OutputTypes.Graphviz:
+            case OutputTypes.Mermaid:
                 if (string.IsNullOrWhiteSpace(outputPath))
                 {
                     Console.Error.WriteLine($"output type {type} require specifying {nameof(outputPath)}");
@@ -37,6 +38,9 @@ internal class ResultWriter
             case OutputTypes.Graphviz:
                 WriteAsGraphvizToFile(result, outputPath);
                 break;
+            case OutputTypes.Mermaid:
+                WriteAsMermaidToFile(result, outputPath);
+                break;
             case OutputTypes.ConsoleJson:
                 WriteAsJsonToConsole(result);
                 break;
@@ -45,6 +49,9 @@ internal class ResultWriter
                 break;
             case OutputTypes.ConsoleGraphviz:
                 WriteAsGraphvizToConsole(result);
+                break;
+            case OutputTypes.ConsoleMermaid:
+                WriteAsMermaidToConsole(result);
                 break;
             default:
                 throw new Exception($"Unknown {nameof(type)} '{type}'");
@@ -95,4 +102,12 @@ internal class ResultWriter
         Console.WriteLine($"GraphViz output written to {outputPath}");
     }
 
+    private static void WriteAsMermaidToConsole(DiscoveryResult result)
+        => Console.WriteLine(MermaidSerializer.ToString(result));
+
+    private static void WriteAsMermaidToFile(DiscoveryResult result, string outputPath)
+    {
+        File.WriteAllText(outputPath, MermaidSerializer.ToString(result));
+        Console.WriteLine($"Mermaid output written to {outputPath}");
+    }
 }

--- a/docs/CommandLine.md
+++ b/docs/CommandLine.md
@@ -74,9 +74,11 @@ Type of output to produce. Following types are available.
 - `Json` - Creates a JSON file.
 - `Xml` - Creates a XML file.
 - `Graphviz` - Creates a Graphviz/DOT file.
+- `Mermaid` - Creates a Mermaid/MMD file.
 - `ConsoleJson` - Writes JSON output to stdout
 - `ConsoleXml` - Writes XML output to stdout
-- `GonsoleGraphviz` - Writes Graphviz output to stdout
+- `ConsoleGraphviz` - Writes Graphviz output to stdout
+- `ConsoleMermaid` - Writes Mermaid output to stdout
 
 When a `Console...` type output is  specified, the `-OutputPath` can be ommitted.
 `Console...` output types may still write warings to `stderr` stream. If you're piping just the `stderr` into another program, consider checking the `stderr` for warnings as well.

--- a/docs/CommandLine.md
+++ b/docs/CommandLine.md
@@ -152,6 +152,20 @@ If you want to include spaces between items, make sure you enclose the parameter
 - `DependenSee \Source\SolutionFolder -O ConsoleJson -EPrN MyApp.Extensions, MyApp.Helpers`
   -  Excludes projects starting with MyApp.Extensions and projects starting with MyApp.Helpers
 
+## TrimProjectNamespaces
+Comma separated list of project file prefixes to trim. Wildcards not allowed. Only the filename is considered, case insensitive. 
+
+**Shorthand: `-TPrN`**
+
+**Default: `<empty string>`**
+
+### Examples
+
+- `DependenSee \Source\SolutionFolder -O ConsoleJson -TrimProjectNamespaces MyApp`
+  -  Displays project names starting with MyApp. 'MyApp.Core' and 'MyApp.Extensions' display as 'Core' and 'Extensions'
+- `DependenSee \Source\SolutionFolder -O ConsoleJson -TPrN MyApp`
+  -  Displays project names starting with MyApp. 'MyApp.Core' and 'MyApp.Extensions' display as 'Core' and 'Extensions'
+
 ## IncludePackageNamespaces
 Comma separated list of package name prefixes to include. Wildcards not allowed. Only the package name is considered, case insensitive. If specified, `-IncludePackages` is overridden to `True`.
 
@@ -170,13 +184,27 @@ If you want to include spaces between items, make sure you enclose the parameter
 
 ## ExcludePackageNamespaces
 
-Comma separated list of package name prefixes to exclude. Wildcards not allowed. Only the filename is considered, case insensitive. If specified, `-IncludePackages` is overridden to `True`. This must be a subset of includes to be useful.
+Comma separated list of package name prefixes to exclude. Wildcards not allowed. Only the package name is considered, case insensitive. If specified, `-IncludePackages` is overridden to `True`. This must be a subset of includes to be useful.
 
 If you want to include spaces between items, make sure you enclose the parameter value in double quotes.
 
 **Shorthand: `-EPaN`**
 
 **Default: `<unspecified>`**
+
+## TrimPackageNamespaces
+Comma separated list of package name prefixes to trim. Wildcards not allowed. Only the package name is considered, case insensitive. If specified, `-IncludePackages` is overridden to `True`.
+
+**Shorthand: `-TPaN`**
+
+**Default: `<empty string>`**
+
+### Examples
+
+- `DependenSee \Source\SolutionFolder -O ConsoleJson -TrimPackageNamespaces MyApp`
+  -  Displays package names starting with MyApp. 'MyApp.Core' and 'MyApp.Extensions' display as 'Core' and 'Extensions'
+- `DependenSee \Source\SolutionFolder -O ConsoleJson -TPaN MyApp`
+  -  Displays package names starting with MyApp. 'MyApp.Core' and 'MyApp.Extensions' display as 'Core' and 'Extensions'
 
 ## FollowReparsePoints
 


### PR DESCRIPTION
- Adds mermaid serializer with file and console output. #40 
- Adds options to reduce display name size of packages and projects. 

Both changes update docs.

The trim options is my own feature request, not in an issue anywhere. The solutions I work on frequently have common namespace prefixes across many projects and packages; and this is a way to make the resulting graphs easier to read.

I understand v3 will in the future extract the output formatting so new serializers like mermaid wouldn't be included in the project; but since 2.x is whats available now I found it trivial to add and get some value before a v3 is ready.