### PR TITLE
Avoid xml load errors with wrong encoding

### DIFF
--- a/DependenSee/ReferenceDiscoveryService.cs
+++ b/DependenSee/ReferenceDiscoveryService.cs
@@ -139,7 +139,10 @@ public class ReferenceDiscoveryService
     private (List<Project> projects, List<Package> packages) DiscoverFileReferences(string path)
     {
         var xml = new XmlDocument();
-        xml.Load(path);
+        using (StreamReader reader = new StreamReader(path))
+        {
+            xml.Load(reader);
+        }
         var basePath = new FileInfo(path).Directory.FullName;
 
         var projects = DiscoverProjectRefrences(xml, basePath);


### PR DESCRIPTION
Avold the error below when loading some XML csproj files.

System.Xml.XmlException:Name cannot begin with the '.' character, hexadecimal value 0x00. Line 1, position 40.

See https://stackoverflow.com/q/51873880/12437590