### PR TITLE
[ * Feature ] add option to take solution file as a starting point

### DIFF
--- a/DependenSee/DependenSee.csproj
+++ b/DependenSee/DependenSee.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MvsSln" Version="2.7.0" />
     <PackageReference Include="PowerArgs" Version="3.6.0" />
   </ItemGroup>
 

--- a/DependenSee/PowerArgsProgram.cs
+++ b/DependenSee/PowerArgsProgram.cs
@@ -78,6 +78,11 @@ public class PowerArgsProgram
     [ArgShortcut("FReP")]
     public bool FollowReparsePoints { get; set; }
 
+    [ArgDefaultValue("")]
+    [ArgDescription("Set if you want the scan a solution file as a starting point in the source folder.")]
+    [ArgShortcut("sln")]
+    [SolutionFileHook]
+    public string SolutionFile { get; set; }
 
     public void Main()
     {
@@ -98,8 +103,29 @@ public class PowerArgsProgram
 
             SourceFolder = SourceFolder,
 
+            SolutionFile= SolutionFile,
+
         };
         var result = service.Discover();
         new ResultWriter().Write(result, OutputType, OutputPath, HtmlTitle);
+    }
+}
+
+
+internal sealed class SolutionFileHook : ArgHook
+{
+    public override void BeforeInvoke(HookContext context)
+    {
+        var args = (PowerArgsProgram)context.Args;
+
+        if (!string.IsNullOrEmpty(args.SolutionFile))
+        {
+            var solutionFullName = Path.Combine(args.SourceFolder, args.SolutionFile);
+
+            if (!File.Exists(solutionFullName))
+            {
+                throw new ValidationArgException($"File not found - {solutionFullName}", new FileNotFoundException());
+            }
+        }
     }
 }

--- a/DependenSee/SolutionDiscoverer.cs
+++ b/DependenSee/SolutionDiscoverer.cs
@@ -1,0 +1,39 @@
+﻿using net.r_eg.MvsSln;
+using net.r_eg.MvsSln.Core;
+
+namespace DependenSee;
+
+internal static class SolutionDiscoverer
+{
+    internal static IEnumerable<string> GetProjects(string solutionFullName)
+    {
+        using var sln = new Sln(solutionFullName, SlnItems.Projects);
+
+        var projectInfos = sln.Result?.ProjectItems ?? Enumerable.Empty<ProjectItem>();
+
+        var projectFiles = projectInfos
+            .Where(IsSharpOrBasic)
+            .Select(info => info.fullPath)
+            .ToList();
+
+        return projectFiles;
+    }
+
+    private static bool IsSharpOrBasic(ProjectItem info)
+    {
+        switch (info.EpType)
+        {
+            case ProjectType.Cs:
+            case ProjectType.CsSdk:
+            case ProjectType.Vb:
+            case ProjectType.VbSdk:
+                {
+                    return true;
+                }
+            default:
+                {
+                    return false;
+                }
+        }
+    }
+}


### PR DESCRIPTION
I've used the MvsSln nuget to parse a solution file as a starting point for the dependency tree.

A new command line arg was added and the code that iterates over the projects refactored into a new method so it can be called from the existing code as well as the result of the solution file.